### PR TITLE
Fix undefined behavior in Deck class

### DIFF
--- a/src/game/deck.cpp
+++ b/src/game/deck.cpp
@@ -2,7 +2,8 @@
 #include "deck.h"
 #include "card.h"
 
-Deck::Deck(bool includeJokers) {
+Deck::Deck(bool _includeJokers) {
+    includeJokers = _includeJokers;
     cardCount = (includeJokers ? 54 : 52);
     Deck::reset();
     // random shuffle by default

--- a/src/game/deck.h
+++ b/src/game/deck.h
@@ -18,7 +18,7 @@ class Deck {
 
  public:
     // Create a deck.
-    Deck(bool includeJokers = false);
+    Deck(bool _includeJokers = false);
     ~Deck();
 
     int getNumRemainingCards() const;


### PR DESCRIPTION
The Deck class currently exhibits undefined behavior in that the includeJokers class variable is never initialized. While the cardCount variable will be initialized correctly it is undefined whether the jokers are actually added to the deck in reset(). I believe this is also why the deckTest3.testDealGivenCards test currently fails on CI.
This issue is also detected by static analysis:
```src/game/deck.cpp:5:7: warning: Member variable 'Deck::includeJokers' is not initialized in the constructor. [uninitMemberVar]```
Please check static analysis in the future before committing.