### PR TITLE
Update CI runner image version, speed up CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,9 +60,11 @@ jobs:
       run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev && python -m pip install --upgrade pip && pip install codespell cpplint
     - name: Set up CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-    - name: Spell check
+    - name: Linting (print)
+      run: cmake --build ${{github.workspace}}/build --target code-lint
+    - name: Spell check (print and assert)
       run: cmake --build ${{github.workspace}}/build --target code-spell-ci
-    - name: Linting
+    - name: Linting (assert)
       run: cmake --build ${{github.workspace}}/build --target code-lint-ci
 #Move static analysis into a separate job since it can be slow
   code-analyze:
@@ -75,5 +77,7 @@ jobs:
       run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev cppcheck
     - name: Set up CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-    - name: Static Analysis
+    - name: Static Analysis (print)
+      run: cmake --build ${{github.workspace}}/build --target code-analyze
+    - name: Static Analysis (assert)
       run: cmake --build ${{github.workspace}}/build --target code-analyze-ci

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build-client:
+  build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
@@ -29,36 +29,10 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-    - name: Build client
+    - name: Build client and server
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --target client --config ${{env.BUILD_TYPE}} -- -j 2
-  build-server-test:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
-    - name: Install libcurl and asio headers
-      #libcurl should already be installed on CI runner, but not in a way that curlpp's cmake can find it
-      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev
-
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-
-    - name: Build server
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --target server --config ${{env.BUILD_TYPE}} -- -j 2
+      run: cmake --build ${{github.workspace}}/build --target client server --config ${{env.BUILD_TYPE}} -- -j 2
   test:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-22.04
 
     steps:
@@ -67,12 +41,9 @@ jobs:
         submodules: recursive
 
     - name: Install libcurl and asio headers
-      #libcurl should already be installed on CI runner, but not in a way that curlpp's cmake can find it
       run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: GTest
       # Execute tests defined by the CMake configuration.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,9 +21,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Install libcurl
+    - name: Install libcurl and asio headers
       #libcurl should already be installed on CI runner, but not in a way that curlpp's cmake can find it
-      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libcurl4-openssl-dev
+      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -55,6 +55,25 @@ jobs:
     - name: Build server
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --target server --config ${{env.BUILD_TYPE}} -- -j 2
+  test:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Install libcurl and asio headers
+      #libcurl should already be installed on CI runner, but not in a way that curlpp's cmake can find it
+      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: GTest
       # Execute tests defined by the CMake configuration.
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,6 +21,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+    - name: Install libcurl
+      #libcurl should already be installed on CI runner, but not in a way that curlpp's cmake can find it
+      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libcurl4-openssl-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -41,8 +44,8 @@ jobs:
         submodules: recursive
 
     - name: Install libcurl and asio headers
-      #libcurl should already be installed on CI runner
-      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev
+      #libcurl should already be installed on CI runner, but not in a way that curlpp's cmake can find it
+      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,11 +11,29 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
+  build-client:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    - name: Build client
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --target client --config ${{env.BUILD_TYPE}} -- -j 2
+  build-server-test:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
@@ -23,23 +41,24 @@ jobs:
         submodules: recursive
 
     - name: Install libcurl and asio headers
-      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev libcurl4-openssl-dev
+      #libcurl should already be installed on CI runner
+      run: sudo apt update && sudo apt install --no-install-recommends --fix-missing -y libasio-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Build
+    - name: Build server
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --target client server --config ${{env.BUILD_TYPE}} -- -j 2
+      run: cmake --build ${{github.workspace}}/build --target server --config ${{env.BUILD_TYPE}} -- -j 2
     - name: GTest
       # Execute tests defined by the CMake configuration.
       run: |
            cmake --build ${{github.workspace}}/build --target tiger-test -- -j 2;
            ${{github.workspace}}/build/tiger-test
   code-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -54,7 +73,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --target code-lint-ci
 #Move static analysis into a separate job since it can be slow
   code-analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(client main.cpp parser.h parser.cpp requester.cpp requester.h util.h util.cpp)
 target_include_directories(client PRIVATE ${TIGER_SOURCE_DIR}/libraries/curlpp/include)
-target_link_libraries(client PRIVATE Crow::Crow curlpp_static)
+target_link_libraries(client PRIVATE curlpp_static)


### PR DESCRIPTION
Updates the CI image to Ubuntu 22.04 (the "latest" version is still set to 20.04) and tries to speed up the build by building the client separately, meaning that curlpp is no longer needed when building the tests and the server.