### PR TITLE
Remove openssl submodule, initial HTTPS setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "src/libraries/curlpp"]
 	path = src/libraries/curlpp
 	url = https://github.com/jpbarrette/curlpp.git
-[submodule "src/libraries/openssl-cmake"]
-	path = src/libraries/openssl-cmake
-	url = https://github.com/janbar/openssl-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,16 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
+find_package(OpenSSL REQUIRED)
 
 set(TIGER_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
 set(TIGER_TEST_DIR ${PROJECT_SOURCE_DIR}/test)
 add_subdirectory(${TIGER_SOURCE_DIR}/server)
 add_subdirectory(${TIGER_SOURCE_DIR}/client)
+set(CROW_FEATURES ssl)
 add_subdirectory(${TIGER_SOURCE_DIR}/libraries/Crow)
 set(CURLPP_BUILD_SHARED_LIBS OFF)
 add_subdirectory(${TIGER_SOURCE_DIR}/libraries/curlpp EXCLUDE_FROM_ALL)
-add_subdirectory(${TIGER_SOURCE_DIR}/libraries/openssl-cmake EXCLUDE_FROM_ALL)
 include_directories(${TIGER_SOURCE_DIR}/libraries/sqlite)
 
 #Import tests so they can be built from the top level.

--- a/src/client/requester.cpp
+++ b/src/client/requester.cpp
@@ -131,6 +131,11 @@ std::string Requester::getPublicStats(std::string type) {
   std::string url = baseUrl + path;
   request.setOpt(new curlpp::options::Url(url));
   request.setOpt(new curlpp::options::WriteStream(&response));
+  //TODO: Put this in every function, also refactor interface to
+  //significantly reduce code clones.
+  //Disable SSL certificate check to allow server to use unsigned certificate.
+  request.setOpt(curlpp::options::SslVerifyPeer(false));
+  request.setOpt(curlpp::options::SslVerifyHost(false));
   request.perform();
   while (response >> tmp) {
     body.push_back(tmp);

--- a/src/client/requester.h
+++ b/src/client/requester.h
@@ -72,7 +72,7 @@ class Requester {
  private:
   curlpp::Cleanup cleaner;
   curlpp::Easy request;
-  std::string baseUrl = "http://127.0.0.1:18080/";
+  std::string baseUrl = "https://127.0.0.1:18080/";
 };
 
 #endif

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,3 +1,11 @@
 include_directories(${TIGER_SOURCE_DIR}/libraries/Crow/include)
-add_executable(server main.cpp util.cpp util.h ../sqliteDB/sql.h ../sqliteDB/sql.cpp ../libraries/sqlite/sqlite3.c ../libraries/sqlite/sqlite3.h)
+add_executable(server main.cpp util.cpp util.h ../sqliteDB/sql.h ../sqliteDB/sql.cpp ../libraries/sqlite/sqlite3.c ../libraries/sqlite/sqlite3.h ${CMAKE_BINARY_DIR}/key.pem ${CMAKE_BINARY_DIR}/cert.pem)
 target_link_libraries(server PRIVATE Crow::Crow ${CMAKE_DL_LIBS})
+
+#Create key and certificate for HTTPS
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/key.pem ${CMAKE_BINARY_DIR}/cert.pem
+  COMMAND openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -subj '/O=CS 4156 Project Tiger/C=US/ST=New York/L=New York/CN=project.tiger' -keyout key.pem -out cert.pem
+  COMMAND touch ${CMAKE_BINARY_DIR}/key.pem ${CMAKE_BINARY_DIR}/cert.pem
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -270,5 +270,17 @@ int main(int argc, char** argv) {
       return getDatabase().getTextValue(mostWinningPlayCommand);
   });
 
+  //Set up SSL, working around Crow issues
+  crow::ssl_context_t ssl_ctx(asio::ssl::context::sslv23);
+  ssl_ctx.set_verify_mode(asio::ssl::verify_none);
+  ssl_ctx.use_certificate_file("cert.pem", crow::ssl_context_t::pem);
+  ssl_ctx.use_private_key_file("key.pem", crow::ssl_context_t::pem);
+  ssl_ctx.set_options(
+      asio::ssl::context::default_workarounds
+      | asio::ssl::context::no_sslv2
+      | asio::ssl::context::no_sslv3
+      );
+  app.ssl(std::move(ssl_ctx));
+
   app.port(18080).multithreaded().run();
 }


### PR DESCRIPTION
Implement HTTPS support. Note that this is not yet complete: Some changes to how the client makes requests are needed, they have only been implemented for /public/* requests since #42 should be resolved first to avoid more bloated code.