### PR TITLE
Switch to openssl-based cryptographic pseudorandom session token

### DIFF
--- a/src/server/util.cpp
+++ b/src/server/util.cpp
@@ -2,7 +2,8 @@
 #include <memory>
 #include <string>
 #include <set>
-
+#include <openssl/rand.h>
+#include <crow.h>
 #include "util.h"
 #include "../sqliteDB/sql.h"
 
@@ -16,10 +17,12 @@ std::string getSession() {
   if (session.compare("")) {
     return session;
   }
-  int randomLocationInMemory = 1000;
-  char randomLocationAsLiteral[9];
-  snprintf(randomLocationAsLiteral, sizeof(randomLocationAsLiteral),
-  "%p", &randomLocationInMemory);
-  session = std::string(randomLocationAsLiteral);
+  unsigned char token_buf [TOKEN_BYTES];
+  int error = RAND_bytes(token_buf, TOKEN_BYTES);
+  //RAND_bytes may fail if the OS runs out of random data – this is
+  //unlikely enough to disregard for this project.
+  (void)error;
+  session = crow::utility::base64encode(token_buf, TOKEN_BYTES);
+  //TODO: Add to token database
   return session;
 }

--- a/src/server/util.cpp
+++ b/src/server/util.cpp
@@ -17,7 +17,7 @@ std::string getSession() {
   if (session.compare("")) {
     return session;
   }
-  unsigned char token_buf [TOKEN_BYTES];
+  unsigned char token_buf[TOKEN_BYTES];
   int error = RAND_bytes(token_buf, TOKEN_BYTES);
   //RAND_bytes may fail if the OS runs out of random data – this is
   //unlikely enough to disregard for this project.

--- a/src/server/util.h
+++ b/src/server/util.h
@@ -15,5 +15,7 @@ std::string getSession();
 
 #define TOKEN_BITS 256
 #define TOKEN_BYTES (TOKEN_BITS / 8)
+//this will change based on TOKEN_BITS, but is non-trivial to calculate
+#define TOKEN_BASE64_LEN 44
 
 #endif // SRC_SERVER_UTIL_H_

--- a/src/server/util.h
+++ b/src/server/util.h
@@ -13,4 +13,7 @@ Database getDatabase();
 // Serves as token for verifying that client is logged in
 std::string getSession();
 
+#define TOKEN_BITS 256
+#define TOKEN_BYTES (TOKEN_BITS / 8)
+
 #endif // SRC_SERVER_UTIL_H_

--- a/src/sqliteDB/sql.h
+++ b/src/sqliteDB/sql.h
@@ -4,7 +4,11 @@
 #include <stdio.h>
 #include <iostream>
 #include <string>
-#include <sqlite3.h>
+
+//Simpler than including the entire sqlite3 header, which is only needed
+//by sql.cpp and stat.cpp.
+struct sqlite3_stmt;
+struct sqlite3;
 
 static int callback(void *count, int argc, char **argv, char **azColName);
 static int countCallback(void *count, int argc, char **argv, char **azColName);

--- a/src/sqliteDB/stat.cpp
+++ b/src/sqliteDB/stat.cpp
@@ -1,6 +1,6 @@
-#include "stat.h"
-
 #include <iostream>
+#include <sqlite3.h>
+#include "stat.h"
 
 // helper function that executes commands
 int runQueryWithIntReturn(Database& db, const std::string& sql_command) {

--- a/test/serverApiTests.cpp
+++ b/test/serverApiTests.cpp
@@ -1,13 +1,16 @@
+#include <regex>
 #include "gtest/gtest.h"
 #include "../src/server/util.h"
 
 TEST(ServerUtilTest, ReturnsUniqueSession) {
   std::string sessionId = getSession();
-  EXPECT_GE(sessionId.size(), 1);
+  EXPECT_EQ(sessionId.size(), TOKEN_BASE64_LEN);
 
-  std::string firstTwoCharsOfSessionId = sessionId.substr(0, 2);
-  std::string memoryLocationPointerPrefix = "0x";
-  ASSERT_EQ(firstTwoCharsOfSessionId, memoryLocationPointerPrefix);
+  //Check if session ID contains characters not allowed in base64
+  //Inspired by https://stackoverflow.com/a/7616973
+  bool contains_non_base64
+    = !std::regex_match(sessionId, std::regex("^[A-Za-z0-9\\+\\/\\=]+$"));
+  ASSERT_FALSE(contains_non_base64);
 }
 
 TEST(ServerUtilTest, ReturnsSameUniqueSession) {

--- a/test/sqliteTest.cpp
+++ b/test/sqliteTest.cpp
@@ -1,6 +1,6 @@
+#include <sqlite3.h>
 #include "gtest/gtest.h"
 #include "../src/sqliteDB/sql.h"
-
 
 TEST(Database_Create_and_Insert, Check_Insert_and_Create_methods) {
     Database del_table = Database("delete.db");


### PR DESCRIPTION
This should be more secure. Using a pointer value is too few bits and an attacker can conceivably predict the location of the stack when getSession is called and thus infer the pointer location.