### PR TITLE
Fix statement handling: sqlite statements always need to be finalized

### DIFF
--- a/src/sqliteDB/sql.cpp
+++ b/src/sqliteDB/sql.cpp
@@ -139,6 +139,7 @@ int Database::getMax(std::string table_name, std::string col_name) {
     sqlite3_step(stmt);
 
     int the_max = sqlite3_column_int(stmt, 0);
+    sqlite3_finalize(stmt);
     return the_max;
 }
 

--- a/src/sqliteDB/stat.cpp
+++ b/src/sqliteDB/stat.cpp
@@ -4,22 +4,20 @@
 
 // helper function that executes commands
 int runQueryWithIntReturn(Database& db, const std::string& sql_command) {
-    sqlite3_stmt* res;
-    res = db.makeStatement(sql_command);
-    sqlite3_step(res);
-    return sqlite3_column_int(res, 0);
+    sqlite3_stmt* stmt = db.makeStatement(sql_command);
+    sqlite3_step(stmt);
+    int ret = sqlite3_column_int(stmt, 0);
+    sqlite3_finalize(stmt);
+    return ret;
 }
 
 std::string runQueryWithSingleReturn(Database& db,
     const std::string& sql_command) {
-    sqlite3_stmt* res;
-    res = db.makeStatement(sql_command);
-    sqlite3_step(res);
-    // check https://en.cppreference.com/w/cpp/language/reinterpret_cast
-    // const unsigned char* -> const char* -> string
-    std::string ret{reinterpret_cast<const char*>(
-        sqlite3_column_text(res, 0))};
-    return ret;
+    sqlite3_stmt* stmt = db.makeStatement(sql_command);
+    sqlite3_step(stmt);
+    const char* ret_str = (const char*)sqlite3_column_text(stmt, 0);
+    sqlite3_finalize(stmt);
+    return std::string(ret_str);
 }
 
 

--- a/test/sqliteTest.cpp
+++ b/test/sqliteTest.cpp
@@ -147,6 +147,13 @@ TEST(Database_Delete, Check_Delete_method) {
     EXPECT_EQ(achieve_count, 0);
     EXPECT_EQ(hosts_count, 0);
     EXPECT_EQ(games_count, 0);
+
+    /*TODO: Technically should call sqlite3_finalize() for each sqlite3_stmt
+     * above, but since we will no longer use the given database this is not
+     * necessary here. If the database is used again or there are any delete
+     * operations added following the statements, they do need to be finalized
+     * to prevent errors since tables cannot be deleted as long as there are
+     * statements referencing them. */
 }
 
 TEST(Database_Drop, Check_Drop_method) {


### PR DESCRIPTION
This fixes the long standing error messages within the stat tests.